### PR TITLE
GNUmakefile: use make's $(CC) and allow a third-party to use whatever

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -205,18 +205,18 @@ uninstall:
 $(BUILD)/obj/%.o: src/%.c
 	$(QUIET_ECHO) $@: Compiling object
 	@ mkdir -p $(dir $(BUILD)/dep/$<)
-	@ gcc $(CFLAGS) -M -MG -MQ $@ -DCOMPILINGDEPENDENCIES \
+	@ $(CC) $(CFLAGS) -M -MG -MQ $@ -DCOMPILINGDEPENDENCIES \
         -o $(BUILD)/dep/$(<:%.c=%.d) -c $<
 	@ mkdir -p $(dir $@)
-	$(VERBOSE_SHOW) gcc $(CFLAGS) -o $@ -c $<
+	$(VERBOSE_SHOW) $(CC) $(CFLAGS) -o $@ -c $<
 
 $(BUILD)/obj/%.do: src/%.c
 	$(QUIET_ECHO) $@: Compiling dynamic object
 	@ mkdir -p $(dir $(BUILD)/dep/$<)
-	@ gcc $(CFLAGS) -M -MG -MQ $@ -DCOMPILINGDEPENDENCIES \
+	@ $(CC) $(CFLAGS) -M -MG -MQ $@ -DCOMPILINGDEPENDENCIES \
         -o $(BUILD)/dep/$(<:%.c=%.dd) -c $<
 	@ mkdir -p $(dir $@)
-	$(VERBOSE_SHOW) gcc $(CFLAGS) -fpic -fPIC -o $@ -c $< 
+	$(VERBOSE_SHOW) $(CC) $(CFLAGS) -fpic -fPIC -o $@ -c $< 
 
 
 # --------------------------------------------------------------------------
@@ -236,7 +236,7 @@ LIBS3_SOURCES := acl.c bucket.c error_parser.c general.c \
 $(LIBS3_SHARED): $(LIBS3_SOURCES:%.c=$(BUILD)/obj/%.do)
 	$(QUIET_ECHO) $@: Building shared library
 	@ mkdir -p $(dir $@)
-	$(VERBOSE_SHOW) gcc -shared -Wl,-soname,libs3.so.$(LIBS3_VER_MAJOR) \
+	$(VERBOSE_SHOW) $(CC) -shared -Wl,-soname,libs3.so.$(LIBS3_VER_MAJOR) \
         -o $@ $^ $(LDFLAGS)
 
 $(LIBS3_STATIC): $(LIBS3_SOURCES:%.c=$(BUILD)/obj/%.o)
@@ -254,7 +254,7 @@ s3: $(BUILD)/bin/s3
 $(BUILD)/bin/s3: $(BUILD)/obj/s3.o $(LIBS3_SHARED)
 	$(QUIET_ECHO) $@: Building executable
 	@ mkdir -p $(dir $@)
-	$(VERBOSE_SHOW) gcc -o $@ $^ $(LDFLAGS)
+	$(VERBOSE_SHOW) $(CC) -o $@ $^ $(LDFLAGS)
 
 
 # --------------------------------------------------------------------------
@@ -278,7 +278,7 @@ test: $(BUILD)/bin/testsimplexml
 $(BUILD)/bin/testsimplexml: $(BUILD)/obj/testsimplexml.o $(LIBS3_STATIC)
 	$(QUIET_ECHO) $@: Building executable
 	@ mkdir -p $(dir $@)
-	$(VERBOSE_SHOW) gcc -o $@ $^ $(LIBXML2_LIBS)
+	$(VERBOSE_SHOW) $(CC) -o $@ $^ $(LIBXML2_LIBS)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
When using distcc to help cross-compiling for platforms other than the
host's native arch, explicitly calling 'gcc' may lead to unfortunate
results, such as objects ending up being remotely compiled for x86_64
and then the local armv6 linker having no idea how to handle them.

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
